### PR TITLE
Fix tab content view recreation

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -25,32 +25,31 @@ import SwiftUI
 import TabBar
 
 struct ContentView: View {
-    
     private enum Item: Int, Tabbable {
         case first = 0
         case second
         case third
-        
+
         var icon: String {
             switch self {
-                case .first: return "house"
-                case .second: return "magnifyingglass"
-                case .third: return "person"
+            case .first: "house"
+            case .second: "magnifyingglass"
+            case .third: "person"
             }
         }
-        
+
         var title: String {
             switch self {
-                case .first: return "First"
-                case .second: return "Second"
-                case .third: return "Third"
+            case .first: "First"
+            case .second: "Second"
+            case .third: "Third"
             }
         }
     }
-    
+
     @State private var selection: Item = .first
     @State private var visibility: TabBarVisibility = .visible
-    
+
     var body: some View {
         TabBar(selection: $selection, visibility: $visibility) {
             Button {
@@ -61,15 +60,32 @@ struct ContentView: View {
                 Text("Hide/Show TabBar")
             }
             .tabItem(for: Item.first)
-            
-            Text("Second")
+
+            TextWrapper()
                 .tabItem(for: Item.second)
-            
-            Text("Third")
+
+            TextWrapper()
                 .tabItem(for: Item.third)
         }
         .tabBar(style: CustomTabBarStyle())
         .tabItem(style: CustomTabItemStyle())
+        .onChange(of: selection) { newValue in
+            print("selection changed:", newValue)
+        }
+    }
+}
+
+struct TextWrapper: View {
+    @State var string: String = UUID().uuidString
+
+    var body: some View {
+        Text(string)
+            .onTapGesture {
+                string = UUID().uuidString
+            }
+            .onAppear(perform: {
+                print("onAppear:", string)
+            })
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,19 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 
 import PackageDescription
 
 let package = Package(
     name: "TabBar",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v14),
     ],
     products: [
         .library(
             name: "TabBar",
             targets: ["TabBar"]
-        )
+        ),
     ],
     targets: [
-        .target(name: "TabBar")
+        .target(name: "TabBar"),
     ]
 )

--- a/Sources/TabBar/Common/Preferences/TabBarSelection.swift
+++ b/Sources/TabBar/Common/Preferences/TabBarSelection.swift
@@ -21,12 +21,35 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
+import Combine
 import SwiftUI
 
 class TabBarSelection<TabItem: Tabbable>: ObservableObject {
-    @Binding var selection: TabItem
-    
+    private var cancelSet = Set<AnyCancellable>()
+
+    @Published var selection: TabItem {
+        didSet {
+            loadedItems.insert(selection)
+        }
+    }
+
+    @Published var items: [TabItem] = [] {
+        didSet {
+            loadedItems = [selection]
+        }
+    }
+
+    @Published var loadedItems = Set<TabItem>()
+
     init(selection: Binding<TabItem>) {
-        self._selection = selection
+        self.selection = selection.wrappedValue
+        loadedItems.insert(selection.wrappedValue)
+
+        $selection.sink { item in
+            DispatchQueue.main.async {
+                selection.wrappedValue = item
+            }
+        }
+        .store(in: &cancelSet)
     }
 }

--- a/Sources/TabBar/Common/Preferences/TabBarViewModifier.swift
+++ b/Sources/TabBar/Common/Preferences/TabBarViewModifier.swift
@@ -25,29 +25,31 @@ import SwiftUI
 
 struct TabBarViewModifier<TabItem: Tabbable>: ViewModifier {
     @EnvironmentObject private var selectionObject: TabBarSelection<TabItem>
-    
+
     let item: TabItem
-    
+
     func body(content: Content) -> some View {
         Group {
-            if self.item == self.selectionObject.selection {
+            if selectionObject.loadedItems.contains(item) {
                 content
+                    .opacity(item == selectionObject.selection ? 1 : 0)
             } else {
                 Color.clear
             }
         }
-        .preference(key: TabBarPreferenceKey.self, value: [self.item])
+        .environmentObject(selectionObject)
+        .preference(key: TabBarPreferenceKey.self, value: [item])
     }
 }
 
-extension View {
+public extension View {
     /**
      A function that is used to associated view with the passed item.
-     
+
      Use this function to associate view with the specific item
      of the `TabBar`.
      */
-    public func tabItem<TabItem: Tabbable>(for item: TabItem) -> some View {
-        return self.modifier(TabBarViewModifier(item: item))
+    func tabItem(for item: some Tabbable) -> some View {
+        modifier(TabBarViewModifier(item: item))
     }
 }


### PR DESCRIPTION
This PR intent to prevent tab content view recreation.
Mainly used StateObject to maintain the state and set opacity=0 to keep the view.  (And aslo support tab content view lazy loading)
Sorry for the many format changes due to SwiftFormat.  Also, I made some modifications to the test the view keeping in the demo. If you don't like it, I can submit a new PR with minimal changes. 