### PR TITLE
feat: do not rerender tab on navigate

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "TabBar",
     platforms: [
-        .iOS(.v13)
+		.iOS("14")
     ],
     products: [
         .library(

--- a/Sources/TabBar/Common/Preferences/TabBarViewModifier.swift
+++ b/Sources/TabBar/Common/Preferences/TabBarViewModifier.swift
@@ -30,11 +30,8 @@ struct TabBarViewModifier<TabItem: Tabbable>: ViewModifier {
     
     func body(content: Content) -> some View {
         Group {
-            if self.item == self.selectionObject.selection {
-                content
-            } else {
-                Color.clear
-            }
+            content
+            .opacity(self.item == self.selectionObject.selection ? 1 : 0)
         }
         .preference(key: TabBarPreferenceKey.self, value: [self.item])
     }

--- a/Sources/TabBar/Common/Preferences/TabBarViewModifier.swift
+++ b/Sources/TabBar/Common/Preferences/TabBarViewModifier.swift
@@ -31,7 +31,7 @@ struct TabBarViewModifier<TabItem: Tabbable>: ViewModifier {
     func body(content: Content) -> some View {
         Group {
             content
-            .opacity(self.item == self.selectionObject.selection ? 1 : 0)
+				.opacity(self.item == self.selectionObject.selection ? 1 : 0)
         }
         .preference(key: TabBarPreferenceKey.self, value: [self.item])
     }

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -114,6 +114,7 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
                 .edgesIgnoringSafeArea(.bottom)
                 .visibility(self.visibility)
             }
+         			.ignoresSafeArea(.keyboard)
         }
         .onPreferenceChange(TabBarPreferenceKey.self) { value in
             self.items = value

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -97,30 +97,30 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
         }
     }
     
-    public var body: some View {
-        ZStack {
-            self.content
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .environmentObject(self.selectedItem)
-            
-            GeometryReader { geometry in
-                VStack {
-                    Spacer()
-                    
-                    self.tabBarStyle.tabBar(with: geometry) {
-                        .init(self.tabItems)
-                    }
-                }
-                .edgesIgnoringSafeArea(.bottom)
-                .visibility(self.visibility)
-            }
-			.ignoresSafeArea(.keyboard)
-        }
-        .onPreferenceChange(TabBarPreferenceKey.self) { value in
-            self.items = value
-        }
-    }
-    
+	public var body: some View {
+		GeometryReader { geometry in
+			ZStack {
+				self.content
+					.frame(maxWidth: .infinity, maxHeight: .infinity)
+					.environmentObject(self.selectedItem)
+					.padding(.bottom, 50 + geometry.safeAreaInsets.bottom)
+				
+				VStack {
+					Spacer()
+					
+					self.tabBarStyle.tabBar(with: geometry) {
+						.init(self.tabItems)
+					}
+				}
+				.edgesIgnoringSafeArea(.bottom)
+				.visibility(self.visibility)
+			}
+			.onPreferenceChange(TabBarPreferenceKey.self) { value in
+				self.items = value
+			}
+		}
+		.ignoresSafeArea(.keyboard)
+	}
 }
 
 extension TabBar {

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -98,11 +98,13 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
     }
     
     public var body: some View {
-        ZStack {
+        VStack {
             self.content
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .environmentObject(self.selectedItem)
             
+			Spacer(minLength: 0)
+			
             GeometryReader { geometry in
                 VStack {
                     Spacer()

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -102,9 +102,9 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
 		GeometryReader { geometry in
 			ZStack {
 				self.content
-					.frame(maxWidth: .infinity, maxHeight: .infinity)
 					.environmentObject(self.selectedItem)
 					.padding(.bottom, 50 + geometry.safeAreaInsets.bottom)
+					.frame(maxWidth: .infinity, maxHeight: .infinity)
 				
 				VStack {
 					Spacer()

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -114,6 +114,7 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
                 .edgesIgnoringSafeArea(.bottom)
                 .visibility(self.visibility)
             }
+			.ignoresSafeArea(.keyboard)
         }
         .onPreferenceChange(TabBarPreferenceKey.self) { value in
             self.items = value

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -96,32 +96,7 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
             .frame(maxWidth: .infinity)
         }
     }
-    
-    public var body: some View {
-        VStack {
-            self.content
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .environmentObject(self.selectedItem)
-            
-			Spacer(minLength: 0)
-			
-            GeometryReader { geometry in
-                VStack {
-                    Spacer()
-                    
-                    self.tabBarStyle.tabBar(with: geometry) {
-                        .init(self.tabItems)
-                    }
-                }
-                .edgesIgnoringSafeArea(.bottom)
-                .visibility(self.visibility)
-            }
-			.ignoresSafeArea(.keyboard)
-        }
-        .onPreferenceChange(TabBarPreferenceKey.self) { value in
-            self.items = value
-        }
-    }
+
     
 	public var body: some View {
 		GeometryReader { geometry in

--- a/Sources/TabBar/View/TabBar.swift
+++ b/Sources/TabBar/View/TabBar.swift
@@ -103,7 +103,7 @@ public struct TabBar<TabItem: Tabbable, Content: View>: View {
 			ZStack {
 				self.content
 					.environmentObject(self.selectedItem)
-					.padding(.bottom, 50 + geometry.safeAreaInsets.bottom)
+					.padding(.bottom, 50)
 					.frame(maxWidth: .infinity, maxHeight: .infinity)
 				
 				VStack {


### PR DESCRIPTION
by using opacity, instead of if; tabs view state stays on changing to another tab. If you have a scroll view and user scrolled, switching tab and returning back preserves scroll view state. Tab view do not reinit.