### PR TITLE
Refactor TabBarVisibility enum

### DIFF
--- a/Sources/TabBar/Common/Preferences/TabBarVisibility.swift
+++ b/Sources/TabBar/Common/Preferences/TabBarVisibility.swift
@@ -51,11 +51,6 @@ public enum TabBarVisibility: CaseIterable {
      state: `visible` will become `invisible` and vice versa.
      */
     public mutating func toggle() {
-        switch self {
-        case .visible:
-            self = .invisible
-        case .invisible:
-            self = .visible
-        }
+        self = self == .visible ? .invisible : .visible
     }
 }


### PR DESCRIPTION
- Simplify `toggle` function using a ternary operator.